### PR TITLE
added idicon html option

### DIFF
--- a/cmd/idicon/README.md
+++ b/cmd/idicon/README.md
@@ -71,3 +71,9 @@ This command will produce the following:
     <rect x="200" y="200" width="50" height="50" style="fill:#76ffc4"></rect>
 </svg>
 ```
+
+### HTML
+
+`idicon html -w 5 -h 5 GeorgeMac`
+
+Same as above but wrapped in `<html><body></body></html>`!

--- a/cmd/idicon/main.go
+++ b/cmd/idicon/main.go
@@ -41,5 +41,7 @@ func main() {
 		fmt.Println(icon)
 	case "svg":
 		fmt.Println(icon.Svg())
+	case "html":
+		fmt.Printf("<html><body>%s</body></html>", icon.Svg())
 	}
 }


### PR DESCRIPTION
`idicon html ...`

produces the same output as `idicon svg` but wrapped in html tags.
